### PR TITLE
[Hotfix] Switch to `//` for URLs to ensure uniform scheme is used

### DIFF
--- a/src/components/Maps/Kenya.js
+++ b/src/components/Maps/Kenya.js
@@ -28,7 +28,7 @@ function KenyaMap({ classes }) {
       </Grid>
       <IframeComponent
         title="Map section"
-        src="http://map.aq.sensors.africa/#9/-1.4272/36.8147"
+        src="//map.aq.sensors.africa/#9/-1.4272/36.8147"
         height="100%"
         width="100%"
         frameBorder="0"

--- a/src/components/Maps/Nigeria.js
+++ b/src/components/Maps/Nigeria.js
@@ -28,7 +28,7 @@ function NigeriaMap({ classes }) {
       </Grid>
       <IframeComponent
         title="Map section"
-        src="http://map.aq.sensors.africa/#6/3.162/7.976"
+        src="//map.aq.sensors.africa/#6/3.162/7.976"
         height="100%"
         width="100%"
         frameBorder="0"

--- a/src/components/Maps/Tanzania.js
+++ b/src/components/Maps/Tanzania.js
@@ -28,7 +28,7 @@ function TanzaniaMap({ classes }) {
       </Grid>
       <IframeComponent
         title="Map section"
-        src="http://map.aq.sensors.africa/#7/-6.937/36.793"
+        src="//map.aq.sensors.africa/#7/-6.937/36.793"
         height="100%"
         width="100%"
         frameBorder="0"


### PR DESCRIPTION
## Description

Map content was being loaded from `http://` while the site runs on `https://` causing blocking of map loading.

## Type of change

Please delete options that are not relevant.

## Screenshots

![screenshot from 2018-10-11 14-57-12](https://user-images.githubusercontent.com/1779590/46802556-53239800-cd66-11e8-9453-b51ebf045b40.png)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation