### PR TITLE
Add "Scroll to Top" on page change

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,7 @@ import { BrowserRouter, Route, Switch } from 'react-router-dom';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 
+import ScrollToTop from './ScrollToTop';
 import Home from './pages';
 import Air, {
   About as AirAbout,
@@ -33,16 +34,18 @@ function App() {
     <MuiThemeProvider theme={THEME}>
       <CssBaseline />
       <BrowserRouter>
-        <Switch>
-          <Route exact path="/" component={Home} />
-          <Route exact path="/air" component={Air} />
-          <Route path="/air/about" component={AirAbout} />
-          <Route path="/air/how-sensors-work" component={AirHowSensorsWork} />
-          <Route path="/air/city" component={AirCity} />
-          <Route path="/air/join-network" component={AirJoinNetwork} />
-          <Route exact path="/water" component={WaterHome} />
-          <Route exact path="/sound" component={SoundHome} />
-        </Switch>
+        <ScrollToTop>
+          <Switch>
+            <Route exact path="/" component={Home} />
+            <Route exact path="/air" component={Air} />
+            <Route path="/air/about" component={AirAbout} />
+            <Route path="/air/how-sensors-work" component={AirHowSensorsWork} />
+            <Route path="/air/city" component={AirCity} />
+            <Route path="/air/join-network" component={AirJoinNetwork} />
+            <Route exact path="/water" component={WaterHome} />
+            <Route exact path="/sound" component={SoundHome} />
+          </Switch>
+        </ScrollToTop>
       </BrowserRouter>
     </MuiThemeProvider>
   );

--- a/src/ScrollToTop.js
+++ b/src/ScrollToTop.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withRouter } from 'react-router';
+
+class ScrollToTop extends React.Component {
+  componentDidUpdate(prevProps) {
+    const { location } = this.props;
+    if (location !== prevProps.location) {
+      window.scrollTo(0, 0);
+    }
+  }
+
+  render() {
+    const { children } = this.props;
+    return children;
+  }
+}
+
+ScrollToTop.propTypes = {
+  location: PropTypes.object.isRequired,
+  children: PropTypes.array
+};
+
+ScrollToTop.defaultProps = {
+  children: []
+};
+
+export default withRouter(ScrollToTop);


### PR DESCRIPTION
## Description

The landscape of [Scroll Restoration](https://github.com/ReactTraining/react-router/blob/master/packages/react-router-dom/docs/guides/scroll-restoration.md) in browsers is changing. While chrome leads the way by handling this automatically, most browsers are not there yet.

This PR adds a default _Scroll to Top_ on page change.

Fixes #94 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Screenshots

### Before

![peek 2018-10-12 17-43](https://user-images.githubusercontent.com/1779590/46876520-3ca13d80-ce47-11e8-91ce-2eb06607b437.gif)

### After

![peek 2018-10-12 17-44](https://user-images.githubusercontent.com/1779590/46876504-33b06c00-ce47-11e8-9dca-fa3f3d3b4eef.gif)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation