### PR TITLE
Add percentage gauge

### DIFF
--- a/src/components/AirComponents/GaugeChart.js
+++ b/src/components/AirComponents/GaugeChart.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { withStyles } from '@material-ui/core/styles';
+
+const styles = {
+  circularChart: {
+    display: 'block',
+    maxWidth: '100%',
+    margin: 'auto'
+  },
+  circularChartWhiteCircle: {
+    stroke: '#fff'
+  },
+  circleBg: {
+    fill: 'none',
+    stroke: '#2FB56B',
+    strokeWidth: '4.8'
+  },
+  percentage: {
+    fill: '#666',
+    stroke: '#666',
+    strokeWidth: '0.25',
+    fontFamily: 'sans-serif',
+    fontSize: '0.35em',
+    textAnchor: 'middle'
+  },
+  circle: {
+    fill: 'none',
+    strokeWidth: '3.8',
+    strokeLinecap: 'none',
+    animation: 'progress 1s ease-out forwards'
+  },
+  '@keyframes progress': {
+    '0%': {
+      strokeDasharray: '0 100'
+    }
+  }
+};
+
+function GaugeChart(props) {
+  const { classes, percentage } = props;
+  return (
+    <svg
+      viewBox="0 0 45 45"
+      className={(classes.circularChart, classes.circularChartWhiteCircle)}
+    >
+      <path
+        className={classes.circleBg}
+        d="M18 2.0845
+            a 15.9155 15.9155 0 0 1 0 31.831
+            a 15.9155 15.9155 0 0 1 0 -31.831"
+      />
+      <path
+        className={classes.circle}
+        strokeDasharray={`${percentage} 100`}
+        d="M18 2.0845
+            a 15.9155 15.9155 0 0 1 0 31.831
+            a 15.9155 15.9155 0 0 1 0 -31.831"
+      />
+      <text x="18" y="20.35" className={classes.percentage}>
+        {percentage}%
+      </text>
+    </svg>
+  );
+}
+
+GaugeChart.propTypes = {
+  classes: PropTypes.object.isRequired,
+  percentage: PropTypes.number.isRequired
+};
+
+export default withStyles(styles)(GaugeChart);

--- a/src/components/AirComponents/GaugeChart.js
+++ b/src/components/AirComponents/GaugeChart.js
@@ -15,7 +15,7 @@ const styles = {
   circleBg: {
     fill: 'none',
     stroke: '#2FB56B',
-    strokeWidth: '4.8'
+    strokeWidth: '4.4'
   },
   percentage: {
     fill: '#666',

--- a/src/components/AirComponents/Issues.js
+++ b/src/components/AirComponents/Issues.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { Grid, Typography } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
 
-import graph from '../../assets/images/Graphs.png';
+import Gauge from './GaugeChart';
 
 const styles = {
   root: {
@@ -57,13 +57,42 @@ function Issues({ classes }) {
           our most common illnesses
         </Typography>
       </Grid>
-      <Grid item xs={12} className={classes.graph}>
-        <img
-          src={graph}
-          alt="Graphs"
-          height="200"
-          style={{ maxWidth: '100%', height: 'auto' }}
-        />
+      <Grid
+        item
+        xs={6}
+        container
+        direction="row"
+        justify="center"
+        alignItems="stretch"
+      >
+        <Grid item xs={6} sm={3}>
+          <Gauge percentage={36} />
+
+          <Typography variant="caption" className={classes.caption}>
+            of lung cancer deaths
+          </Typography>
+        </Grid>
+        <Grid item xs={6} sm={3}>
+          <Gauge percentage={34} />
+
+          <Typography variant="caption" className={classes.caption}>
+            of stroke deaths
+          </Typography>
+        </Grid>
+        <Grid item xs={6} sm={3}>
+          <Gauge percentage={27} />
+
+          <Typography variant="caption" className={classes.caption}>
+            of heart disease deaths
+          </Typography>
+        </Grid>
+        <Grid item xs={6} sm={3}>
+          <Gauge percentage={35} />
+
+          <Typography variant="caption" className={classes.caption}>
+            of COPD (pulmonary disease deaths)
+          </Typography>
+        </Grid>
       </Grid>
     </Grid>
   );

--- a/src/components/AirComponents/Issues.js
+++ b/src/components/AirComponents/Issues.js
@@ -20,11 +20,15 @@ const styles = {
     textAlign: 'center'
   },
   caption: {
-    paddingTop: '1rem',
+    paddingTop: '0',
     textAlign: 'center'
   },
   graph: {
     textAlign: 'center'
+  },
+  svgContainer: {
+    paddingTop: '3rem',
+    paddingBottom: '2rem'
   }
 };
 
@@ -59,11 +63,13 @@ function Issues({ classes }) {
       </Grid>
       <Grid
         item
-        xs={6}
+        xs={8}
+        spacing={24}
         container
         direction="row"
         justify="center"
-        alignItems="stretch"
+        alignItems="strench"
+        className={classes.svgContainer}
       >
         <Grid item xs={6} sm={3}>
           <Gauge percentage={36} />


### PR DESCRIPTION
## Description

Added SVG gauge that uses `percentage` prop to draw the percentage arc like shape.
See screenshot 👇 

Fixes #91 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshots
![image](https://user-images.githubusercontent.com/3693563/46904958-50a37880-cef5-11e8-9e44-ce7d7b1da48b.png)
>


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation