### PR TITLE
[WIP] Improve homepage description box

### DIFF
--- a/src/components/Landing/Hero.js
+++ b/src/components/Landing/Hero.js
@@ -22,6 +22,11 @@ const styles = theme => ({
     [theme.breakpoints.up('md')]: {
       height: '90vh'
     }
+  },
+  intro: {
+    color: 'white',
+    fontWeight: 'bold',
+    fontSize: '2.5em'
   }
 });
 
@@ -39,8 +44,8 @@ function Hero({ classes }) {
         </Link>
       </Grid>
 
-      <Grid item xs={12}>
-        <Typography variant="h5" align="center" style={{ color: 'white' }}>
+      <Grid item xs={6}>
+        <Typography variant="h5" align="center" className={classes.intro}>
           We are here to give you actionable information about the quality of
           your air, water and sound.
         </Typography>

--- a/src/components/Landing/TestQuality.js
+++ b/src/components/Landing/TestQuality.js
@@ -18,14 +18,14 @@ const styles = theme => ({
   img: {
     height: 200,
     width: 'auto',
-    padding: '3rem',
+    padding: '2em',
     marginLeft: 'auto',
     marginRight: 'auto'
   },
   airCard: {
     backgroundColor: '#2FB56B',
     borderRadius: 0,
-    height: 250,
+    height: 200,
     width: '100%',
     [theme.breakpoints.up('sm')]: {
       width: 250
@@ -34,7 +34,7 @@ const styles = theme => ({
   waterCard: {
     backgroundColor: '#4972B8',
     borderRadius: 0,
-    height: 250,
+    height: 200,
     width: '100%',
     [theme.breakpoints.up('sm')]: {
       width: 250
@@ -43,11 +43,17 @@ const styles = theme => ({
   soundCard: {
     backgroundColor: '#B64598',
     borderRadius: 0,
-    height: 250,
+    height: 200,
     width: '100%',
     [theme.breakpoints.up('sm')]: {
       width: 250
     }
+  },
+  testTitle: {
+    fontSize: '1em',
+    fontWeight: 'bold',
+    color: 'white',
+    textTransform: 'uppercase'
   }
 });
 
@@ -64,7 +70,7 @@ function TestQuality({ classes }) {
           variant="h6"
           gutterBottom
           align="center"
-          style={{ color: 'white', textTransform: 'uppercase' }}
+          className={classes.testTitle}
         >
           Test the quality of the city&apos;s
         </Typography>


### PR DESCRIPTION
## Description

Improve image size on the homepage and style introductory description to resemble the design

Fixes #89 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots
<img width="1677" alt="screenshot 2018-10-14 at 02 42 34" src="https://user-images.githubusercontent.com/6592749/46911105-d574ad80-cf5a-11e8-9044-cc6a34c054ee.png">

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation