### PR TITLE
fix logo index on city page model

### DIFF
--- a/src/components/CityComponents/Header/CityMenuBar.js
+++ b/src/components/CityComponents/Header/CityMenuBar.js
@@ -24,6 +24,10 @@ const styles = theme => ({
   },
   iconContainer: {
     paddingTop: '2rem'
+  },
+  logo: {
+    zIndex: '1301',
+    position: 'relative'
   }
 });
 
@@ -39,7 +43,9 @@ function CityMenuBar({ classes, handleChange }) {
         <Grid container alignItems="flex-start">
           <Grid item>
             <Link to="/">
-              <img src={logowhite} alt="Sensors Africa Logo" height="100" />
+              <img src={logowhite}
+                className={classes.logo}
+                alt="Sensors Africa Logo" height="100" />
             </Link>
           </Grid>
           <Grid item>


### PR DESCRIPTION
## Description

On pressing the hamburger on air city page, the logo appears behind the modal instead it should appear above the modal

Fixes # (issue)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots
![screenshot from 2018-11-01 11-21-14](https://user-images.githubusercontent.com/7962097/47841066-6e178400-ddc9-11e8-95be-d6b479f197a1.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation