### PR TITLE
161672537 Adjust default map zoom

### DIFF
--- a/src/pages/air/City.js
+++ b/src/pages/air/City.js
@@ -22,7 +22,7 @@ const CITIES_LOCATION = {
     name: 'Nairobi',
     country: 'Kenya',
     label: 'Nairobi, Kenya',
-    location: '9/-1.4272/36.8147'
+    location: '12/-1.2709/36.8169'
   },
   lagos: {
     latitude: '6.',
@@ -30,7 +30,7 @@ const CITIES_LOCATION = {
     name: 'Lagos',
     country: 'Nigeria',
     label: 'Lagos, Nigeria',
-    location: '6/3.162/7.976'
+    location: '12/6.4552/3.4198'
   },
   'dar-es-salaam': {
     latitude: '-6.',
@@ -38,7 +38,7 @@ const CITIES_LOCATION = {
     name: 'Dar es Salaam',
     country: 'Tanzania',
     label: 'Dar-es-salaam, Tanzania',
-    location: '7/-6.937/36.793'
+    location: '12/-6.8555/39.1518'
   }
 };
 const CITIES_POLLUTION_STATS = {


### PR DESCRIPTION
## Description

The start zoom for most of the cities are a lot further away trying to cover the entire "county" or region but we have sensors primarily in the "central business districts".

We should therefore default them to be a lot closer to cluster of sensors instead of defining according to geographic region.

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Screenshots

### Nairobi

![nairobi](https://user-images.githubusercontent.com/1779590/48716749-0cf50a80-ec29-11e8-86bb-8796f6379982.png)

### Dar es Salaam

![dar](https://user-images.githubusercontent.com/1779590/48716763-167e7280-ec29-11e8-9aed-fce58d207258.png)

### Lagos

![lagos](https://user-images.githubusercontent.com/1779590/48716770-1c745380-ec29-11e8-8665-1d7f0bb98aeb.png)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation