### PR TITLE
[Fix] Mobile view chart labels

### DIFF
--- a/src/components/City/QualityStatsGraph.js
+++ b/src/components/City/QualityStatsGraph.js
@@ -26,12 +26,15 @@ const styles = theme => ({
 
 function QualityStatsGraph({ classes, data, width }) {
   let chartWidth = window.innerWidth;
-  if (width === 'md') {
+  let labelAngle = 45;
+  if (isWidthUp('md', width)) {
     chartWidth = 59.625 * 16;
-  } else if (isWidthUp('lg', width)) {
-    chartWidth = 79.5 * 16;
+    labelAngle = 0;
+    if (isWidthUp('lg', width)) {
+      chartWidth = 79.5 * 16;
+    }
   }
-  const chartHeight = chartWidth * (6 / 16);
+  const chartHeight = chartWidth * (6 / 16) + 20;
 
   return (
     <Grid
@@ -59,9 +62,13 @@ function QualityStatsGraph({ classes, data, width }) {
                   stroke: 'rgba(0,0,0,0.1)',
                   strokeDasharray: ''
                 },
+                ticks: {
+                  // padding: 20
+                },
                 tickLabels: {
                   fontFamily: '"Montserrat", "sans-serif"',
-                  fontWeight: 'bold'
+                  fontWeight: 'bold',
+                  angle: labelAngle
                 }
               }}
             />
@@ -81,6 +88,7 @@ function QualityStatsGraph({ classes, data, width }) {
                   fontWeight: 'bold'
                 }
               }}
+              fixLabelOverlap
             />
             <VictoryLine
               data={data}


### PR DESCRIPTION
## Description

Fix mobile view chart labels: Show them at 45 degrees (x axis) and skip some in y-axis (use `fixLabelOverlap: true`)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Screenshots

### Mobile

![screenshot from 2019-03-06 12-39-31](https://user-images.githubusercontent.com/1779590/53871783-fde66c80-400d-11e9-8312-e2cc7fb34579.png)

### Desktop

![screenshot from 2019-03-06 12-40-09](https://user-images.githubusercontent.com/1779590/53871797-0343b700-400e-11e9-8595-56c5d7437a03.png)

### Current (mobile)

![screenshot from 2019-03-06 12-49-40](https://user-images.githubusercontent.com/1779590/53872036-63d2f400-400e-11e9-9d7d-9b5f760262c7.png)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation