### PR TITLE
Add Embed Components Documentation to Site

### DIFF
--- a/src/components/City/HostSensors/ShareButton/index.js
+++ b/src/components/City/HostSensors/ShareButton/index.js
@@ -106,7 +106,7 @@ class ShareButton extends React.Component {
                   variant="caption"
                   className={classes.typography}
                 >
-                  Embed this project into your website by using the following
+                  Embed this dial into your website by using the following
                   iframe:
                 </Typography>
                 <Embed />

--- a/src/components/EmbedDocumentation.js
+++ b/src/components/EmbedDocumentation.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { Typography } from '@material-ui/core';
+import { withStyles } from '@material-ui/core/styles';
+
+const styles = {
+  root: {
+    padding: '0 5rem',
+    backgroundColor: 'white'
+  },
+  title: {
+    textAlign: 'center',
+    fontWeight: 'bold'
+  }
+};
+
+function EmbedDocumentation({ classes }) {
+  return (
+    <div className={classes.root}>
+      <Typography variant="h6" className={classes.title}>
+        Share/Embed components with the following links:
+      </Typography>
+      <p>Sensor map https://sensors.africa/embeded/air/map?city=nairobi.</p>
+      <p>
+        Embed it in a page example:
+        <pre>{`
+        <iframe
+          src="https://sensors.africa/embeded/air/map?city=nairobi"
+          height="500px"
+          width="800px"
+        />
+      `}</pre>
+      </p>
+      <p>
+        Weekly data graph https://sensors.africa/embeded/air/graph?city=nairobi.
+      </p>
+      <p>
+        Embed it in a page example:
+        <pre>{`
+        <iframe
+          src="https://sensors.africa/embeded/air/graph?city=nairobi"
+          height="500px"
+          width="800px"
+        />
+      `}</pre>
+      </p>
+      <p>The dial https://sensors.africa/embeded/air/dial?city=nairobi.</p>
+      <p>
+        Embed it in a page example:
+        <pre>{`
+        <iframe
+          src="https://sensors.africa/embeded/air/dial?city=nairobi"
+          height="500px"
+          width="800px"
+        />
+      `}</pre>
+      </p>
+    </div>
+  );
+}
+
+EmbedDocumentation.propTypes = {
+  classes: PropTypes.object.isRequired
+};
+
+export default withStyles(styles)(EmbedDocumentation);

--- a/src/components/EmbedDocumentation.js
+++ b/src/components/EmbedDocumentation.js
@@ -1,62 +1,282 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Typography } from '@material-ui/core';
+import { Grid, Typography } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
 
-const styles = {
+const styles = theme => ({
   root: {
-    padding: '0 5rem',
+    flexGrow: 1,
     backgroundColor: 'white'
   },
-  title: {
+  main: {
+    paddingBottom: '3rem',
+    [theme.breakpoints.up('md')]: {
+      width: '59.625rem'
+    },
+    [theme.breakpoints.up('lg')]: {
+      width: '79.5rem'
+    }
+  },
+  link: { color: theme.palette.primary.dark },
+  typography: {
+    paddingTop: theme.spacing.unit * 6,
     textAlign: 'center',
     fontWeight: 'bold'
+  },
+  title: {
+    fontWeight: 700,
+    fontSize: '1rem',
+    paddingTop: '2rem',
+    paddingBottom: '1rem'
+  },
+  dlFirst: {
+    padding: '1rem 0.5rem',
+    borderTop: '1px solid #f0f4f7',
+    borderBottom: '1px solid #f0f4f7',
+    [theme.breakpoints.up('md')]: {
+      paddingLeft: 0,
+      paddingRight: 0
+    }
+  },
+  dl: {
+    padding: '1rem 0.5rem',
+    borderBottom: '1px solid #f0f4f7',
+    [theme.breakpoints.up('md')]: {
+      paddingLeft: 0,
+      paddingRight: 0
+    }
+  },
+  dt: {
+    [theme.breakpoints.up('md')]: {
+      width: '29.8125rem'
+    },
+    [theme.breakpoints.up('lg')]: {
+      width: '39.75rem'
+    },
+    marginBottom: '0.5rem'
+  },
+  dd: {
+    [theme.breakpoints.up('md')]: {
+      width: '29.8125rem',
+      float: 'left'
+    },
+    [theme.breakpoints.up('lg')]: {
+      width: '39.75rem'
+    }
+  },
+  code: {
+    display: 'inline-block',
+    color: theme.palette.secondary.main,
+    fontSize: theme.typography.caption.fontSize
+  },
+  query: {
+    fontSize: theme.typography.caption.fontSize
+  },
+  queryParam: {
+    color: theme.palette.primary.dark,
+    fontSize: theme.typography.caption.fontSize
+  },
+  queryDescription: {
+    fontSize: theme.typography.caption.fontSize
+  },
+  var: {
+    color: theme.palette.primary.dark,
+    fontStyle: 'italic',
+    fontSize: theme.typography.caption.fontSize
+  },
+  wiki: {
+    marginTop: '2rem'
   }
-};
+});
 
 function EmbedDocumentation({ classes }) {
   return (
-    <div className={classes.root}>
-      <Typography variant="h6" className={classes.title}>
-        Share/Embed components with the following links:
-      </Typography>
-      <p>Sensor map https://sensors.africa/embeded/air/map?city=nairobi.</p>
-      <p>
-        Embed it in a page example:
-        <pre>{`
-        <iframe
-          src="https://sensors.africa/embeded/air/map?city=nairobi"
-          height="500px"
-          width="800px"
-        />
-      `}</pre>
-      </p>
-      <p>
-        Weekly data graph https://sensors.africa/embeded/air/graph?city=nairobi.
-      </p>
-      <p>
-        Embed it in a page example:
-        <pre>{`
-        <iframe
-          src="https://sensors.africa/embeded/air/graph?city=nairobi"
-          height="500px"
-          width="800px"
-        />
-      `}</pre>
-      </p>
-      <p>The dial https://sensors.africa/embeded/air/dial?city=nairobi.</p>
-      <p>
-        Embed it in a page example:
-        <pre>{`
-        <iframe
-          src="https://sensors.africa/embeded/air/dial?city=nairobi"
-          height="500px"
-          width="800px"
-        />
-      `}</pre>
-      </p>
-    </div>
+    <Grid
+      container
+      className={classes.root}
+      justify="center"
+      alignItems="center"
+    >
+      <Grid
+        item
+        container
+        justify="center"
+        alignItems="center"
+        className={classes.main}
+      >
+        <Grid item xs={12}>
+          <Typography
+            variant="h6"
+            className={classes.typography}
+            component="h2"
+          >
+            Embed Sensors Components
+          </Typography>
+        </Grid>
+        <Grid item xs={12}>
+          <Typography variant="h6" className={classes.title} component="h3">
+            Embeding Widgets
+          </Typography>
+        </Grid>
+        <Grid item xs={12}>
+          <Typography variant="body2" component="p">
+            The primary way to embed sensors.AFRICA widgets is via iframes.
+            There are three embedable widgets:
+          </Typography>
+        </Grid>
+        <Grid
+          item
+          xs={12}
+          container
+          justify="flex-start"
+          alignItems="flex-start"
+          className={classes.dlFirst}
+        >
+          <Grid item className={classes.dt}>
+            <a
+              className={classes.link}
+              href="https://sensors.africa/embeded/air/map?city=nairobi"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <code className={classes.code}>
+                https://sensors.africa/embeded/air/map?city=city-slug
+              </code>
+            </a>
+          </Grid>
+          <Grid className={classes.dd}>
+            <Typography variant="body2" component="p">
+              City Sensors Map
+            </Typography>
+            <Typography variant="body2">
+              Embed it in a page where:{' '}
+              <code className={classes.var}>city-slug=nairobi</code>
+            </Typography>
+            <Typography
+              variant="body2"
+              component="ul"
+              style={{ listStyle: 'none', marginTop: '0.5rem' }}
+            >
+              <li className={classes.query}>
+                <pre className={classes.queryParam}>
+                  {`
+<iframe src="https://sensors.africa/embeded/air/map?city=nairobi"
+        name="sensors-graph-nairobi"
+        title="sensors.AFRICA | Nairobi Sensors Map"
+        scrolling="no"
+        frameborder="0"
+        height="500px"
+        width="800px"
+        allowfullscreen />
+                `}
+                </pre>
+              </li>
+            </Typography>
+          </Grid>
+        </Grid>
+        <Grid
+          item
+          xs={12}
+          container
+          justify="flex-start"
+          alignItems="flex-start"
+          className={classes.dlFirst}
+        >
+          <Grid item className={classes.dt}>
+            <a
+              className={classes.link}
+              href="https://sensors.africa/embeded/air/graph?city=nairobi"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <code className={classes.code}>
+                https://sensors.africa/embeded/air/graph?city=city-slug
+              </code>
+            </a>
+          </Grid>
+          <Grid className={classes.dd}>
+            <Typography variant="body2" component="p">
+              City Weekly Air Quality Graph
+            </Typography>
+            <Typography variant="body2">
+              Embed it in a page where:{' '}
+              <code className={classes.var}>city-slug=nairobi</code>
+            </Typography>
+            <Typography
+              variant="body2"
+              component="ul"
+              style={{ listStyle: 'none', marginTop: '0.5rem' }}
+            >
+              <li className={classes.query}>
+                <pre className={classes.queryParam}>
+                  {`
+<iframe src="https://sensors.africa/embeded/air/graph?city=nairobi"
+        name="sensors-graph-nairobi"
+        title="sensors.AFRICA | Nairobi Weekly AQ Graph"
+        scrolling="no"
+        frameborder="0"
+        height="500px"
+        width="800px"
+        allowfullscreen />
+                `}
+                </pre>
+              </li>
+            </Typography>
+          </Grid>
+        </Grid>
+        <Grid
+          item
+          xs={12}
+          container
+          justify="flex-start"
+          alignItems="flex-start"
+          className={classes.dl}
+        >
+          <Grid item className={classes.dt}>
+            <a
+              className={classes.link}
+              href="https://sensors.africa/embeded/air/map?city=nairobi"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <code className={classes.code}>
+                https://sensors.africa/embeded/air/dial?city=city-slug
+              </code>
+            </a>
+          </Grid>
+          <Grid className={classes.dd}>
+            <Typography variant="body2" component="p">
+              City PM<sub>2.5</sub> 24 Hours Exposure Dial
+            </Typography>
+            <Typography variant="body2">
+              Embed it in a page where:{' '}
+              <code className={classes.var}>city-slug=nairobi</code>
+            </Typography>
+            <Typography
+              variant="body2"
+              component="ul"
+              style={{ listStyle: 'none', marginTop: '0.5rem' }}
+            >
+              <li className={classes.query}>
+                <pre className={classes.queryParam}>
+                  {`
+<iframe src="https://sensors.africa/embeded/air/dial?city=nairobi"
+        name="sensors-dial-nairobi"
+        title="sensors.AFRICA | Nairobi AQ Dial"
+        scrolling="no"
+        frameborder="0"
+        height="400"
+        width="100%"
+        allowfullscreen />
+                `}
+                </pre>
+              </li>
+            </Typography>
+          </Grid>
+        </Grid>
+      </Grid>
+    </Grid>
   );
 }
 

--- a/src/components/EmbedDocumentation.js
+++ b/src/components/EmbedDocumentation.js
@@ -111,18 +111,18 @@ function EmbedDocumentation({ classes }) {
             className={classes.typography}
             component="h2"
           >
-            Embed Sensors Components
+            Embeding Sensors Widgets
           </Typography>
         </Grid>
         <Grid item xs={12}>
           <Typography variant="h6" className={classes.title} component="h3">
-            Embeding Widgets
+            Embeding City Widgets
           </Typography>
         </Grid>
         <Grid item xs={12}>
           <Typography variant="body2" component="p">
-            The primary way to embed sensors.AFRICA widgets is via iframes.
-            There are three embedable widgets:
+            The primary way to embed sensors.AFRICA city widgets is via iframes.
+            There are three embedable city widgets:
           </Typography>
         </Grid>
         <Grid

--- a/src/pages/air/Data.js
+++ b/src/pages/air/Data.js
@@ -9,6 +9,7 @@ import Navbar from '../../components/Header/Navbar';
 import DataArchivesHeader from '../../components/DataArchives/DataArchivesHeader';
 
 import DataArchives from '../../components/DataArchives/DataArchives';
+import EmbedDocumentation from '../../components/EmbedDocumentation';
 import PartnerLogos from '../../components/PartnerLogos';
 import Footer from '../../components/Footer';
 import Support from '../../components/Support';
@@ -27,45 +28,7 @@ function Data({ classes, url }) {
       <Navbar />
       <DataArchivesHeader />
       <DataArchives />
-      <div>
-        <h2>Share/Embed components with the following links:</h2>
-        <p>Sensor map https://sensors.africa/embeded/air/map?city=nairobi.</p>
-        <p>
-          Embed it in a page example:
-          <pre>{`
-            <iframe
-              src="https://sensors.africa/embeded/air/map?city=nairobi"
-              height="500px"
-              width="800px"
-            />
-          `}</pre>
-        </p>
-        <p>
-          Weekly data graph
-          https://sensors.africa/embeded/air/graph?city=nairobi.
-        </p>
-        <p>
-          Embed it in a page example:
-          <pre>{`
-            <iframe
-              src="https://sensors.africa/embeded/air/graph?city=nairobi"
-              height="500px"
-              width="800px"
-            />
-          `}</pre>
-        </p>
-        <p>The dial https://sensors.africa/embeded/air/dial?city=nairobi.</p>
-        <p>
-          Embed it in a page example:
-          <pre>{`
-            <iframe
-              src="https://sensors.africa/embeded/air/dial?city=nairobi"
-              height="500px"
-              width="800px"
-            />
-          `}</pre>
-        </p>
-      </div>
+      <EmbedDocumentation />
       <Stories />
       <Support classNames={classes.dataSupport} />
       <PartnerLogos />

--- a/src/pages/air/Data.js
+++ b/src/pages/air/Data.js
@@ -27,6 +27,45 @@ function Data({ classes, url }) {
       <Navbar />
       <DataArchivesHeader />
       <DataArchives />
+      <div>
+        <h2>Share/Embed components with the following links:</h2>
+        <p>Sensor map https://sensors.africa/embeded/air/map?city=nairobi.</p>
+        <p>
+          Embed it in a page example:
+          <pre>{`
+            <iframe
+              src="https://sensors.africa/embeded/air/map?city=nairobi"
+              height="500px"
+              width="800px"
+            />
+          `}</pre>
+        </p>
+        <p>
+          Weekly data graph
+          https://sensors.africa/embeded/air/graph?city=nairobi.
+        </p>
+        <p>
+          Embed it in a page example:
+          <pre>{`
+            <iframe
+              src="https://sensors.africa/embeded/air/graph?city=nairobi"
+              height="500px"
+              width="800px"
+            />
+          `}</pre>
+        </p>
+        <p>The dial https://sensors.africa/embeded/air/dial?city=nairobi.</p>
+        <p>
+          Embed it in a page example:
+          <pre>{`
+            <iframe
+              src="https://sensors.africa/embeded/air/dial?city=nairobi"
+              height="500px"
+              width="800px"
+            />
+          `}</pre>
+        </p>
+      </div>
       <Stories />
       <Support classNames={classes.dataSupport} />
       <PartnerLogos />


### PR DESCRIPTION
## Description

Adds the embed documentation to the website.
There are no designs so open to design changes and review of wording.

Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshots

###  Data page

![Screenshot_2019-03-25 sensors AFRICA Air DATA](https://user-images.githubusercontent.com/1779590/54902767-49908580-4eeb-11e9-9833-cb19efc7fa9e.png)

### City page `Share Button`

![Screen Shot 2019-03-25 at 8 33 05 AM](https://user-images.githubusercontent.com/4308339/54897242-a9316580-4ed8-11e9-8f59-7582c4d58e3e.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation